### PR TITLE
+ fixed bug with mob spawning for signs from 1.20.4

### DIFF
--- a/src/main/java/com/magmaguy/betterstructures/schematics/SchematicContainer.java
+++ b/src/main/java/com/magmaguy/betterstructures/schematics/SchematicContainer.java
@@ -7,7 +7,7 @@ import com.magmaguy.betterstructures.config.schematics.SchematicConfigField;
 import com.magmaguy.betterstructures.config.treasures.TreasureConfig;
 import com.magmaguy.betterstructures.config.treasures.TreasureConfigFields;
 import com.magmaguy.betterstructures.util.WarningMessage;
-import com.sk89q.jnbt.ListTag;
+import com.magmaguy.betterstructures.util.WorldEditUtils;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -24,7 +24,6 @@ import org.bukkit.util.Vector;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class SchematicContainer {
     @Getter
@@ -95,11 +94,11 @@ public class SchematicContainer {
                             minecraftMaterial.equals(Material.WARPED_WALL_SIGN)) {
                         BaseBlock baseBlock = clipboard.getFullBlock(translatedLocation);
                         //For future reference, I don't know how to get the data in any other way than parsing the string. Sorry!
-                        String line1 = getLine(baseBlock, 1);
+                        String line1 = WorldEditUtils.getLine(baseBlock, 1);
 
                         //Case for spawning a vanilla mob
                         if (line1.toLowerCase().contains("[spawn]")) {
-                            String line2 = getLine(baseBlock, 2).toUpperCase();
+                            String line2 = WorldEditUtils.getLine(baseBlock, 2).toUpperCase();
                             EntityType entityType;
                             try {
                                 entityType = EntityType.valueOf(line2);
@@ -116,7 +115,7 @@ public class SchematicContainer {
                                 return;
                             }
                             String filename = "";
-                            for (int i = 2; i < 5; i++) filename += getLine(baseBlock, i);
+                            for (int i = 2; i < 5; i++) filename += WorldEditUtils.getLine(baseBlock, i);
                             eliteMobsSpawns.put(new Vector(x, y, z), filename);
                         } else if (line1.toLowerCase().contains("[mythicmobs]")) { // carm start - Support MythicMobs
                             if (Bukkit.getPluginManager().getPlugin("MythicMobs") == null) {
@@ -125,8 +124,8 @@ public class SchematicContainer {
                                 valid = false;
                                 return;
                             }
-                            String mob = getLine(baseBlock, 2);
-                            String level = getLine(baseBlock, 3);
+                            String mob = WorldEditUtils.getLine(baseBlock, 2);
+                            String level = WorldEditUtils.getLine(baseBlock, 3);
                             mythicMobsSpawns.put(new Vector(x, y, z), mob + (level.isEmpty() ? "" : ":" + level));
                         } // carm end - Support MythicMobs
                     }
@@ -142,48 +141,6 @@ public class SchematicContainer {
         }
         if (valid)
             generatorConfigFields.getStructureTypes().forEach(structureType -> schematics.put(structureType, this));
-    }
-
-    /**
-     * As of Minecraft 1.20 Minecraft / WorldEdit have changed the format for the signs. This just bruteforces it.
-     *
-     * @param line
-     * @return
-     */
-    private static String getLine(BaseBlock baseBlock, int line) {
-        String finalLine = "";
-        try {
-            finalLine = cleanLine(baseBlock.getNbtData().getString("Text" + line));
-        } catch (Exception e) {
-            //meh
-        }
-        if (!finalLine.isEmpty()) return finalLine;
-
-        try {
-            finalLine = cleanLine(((ListTag) ((Map) baseBlock.getNbtData().getValue().get("front_text").getValue()).get("messages")).getString(line - 1));
-        } catch (Exception e) {
-            //meh
-        }
-        if (!finalLine.isEmpty()) return finalLine;
-
-        try {
-            finalLine = cleanLine(((ListTag) ((Map) baseBlock.getNbtData().getValue().get("back_text").getValue()).get("messages")).getString(line));
-        } catch (Exception e) {
-            //meh
-        }
-
-        return finalLine;
-    }
-
-    /**
-     * Removes the JSON formatting
-     *
-     * @param jsonLine String to clean
-     * @return A value that can be read directly
-     */
-    private static String cleanLine(String jsonLine) {
-        if (jsonLine.split(":").length < 2) return "";
-        return jsonLine.split(":")[1].replace("\"", "").replace("}", "");
     }
 
     public static void shutdown() {

--- a/src/main/java/com/magmaguy/betterstructures/util/WorldEditUtils.java
+++ b/src/main/java/com/magmaguy/betterstructures/util/WorldEditUtils.java
@@ -1,12 +1,106 @@
 package com.magmaguy.betterstructures.util;
 
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.ListTag;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
+import org.checkerframework.checker.index.qual.Positive;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class WorldEditUtils {
+
+    private static final ArrayList<String> values = new ArrayList<>();
+
     public static Vector getSchematicOffset(Clipboard clipboard) {
         return new Vector(clipboard.getMinimumPoint().getX() - clipboard.getOrigin().getX(),
                 clipboard.getMinimumPoint().getY() - clipboard.getOrigin().getY(),
                 clipboard.getMinimumPoint().getZ() - clipboard.getOrigin().getZ());
+    }
+
+    /**
+     * <p>Parses data from a sign's NBT and returns the specified line number.
+     * Tested with <b>WorldEdit and FastAsyncWorldEdit</b> NBT format.</p>
+     * <p>Compatibility with version 1.20.4 has been added.</p>
+     */
+    public static String getLine(@NotNull BaseBlock baseBlock, @Positive int line) {
+        values.clear();
+        if (baseBlock.getNbtData() == null) {
+            return "";
+        }
+        CompoundTag data = baseBlock.getNbtData();
+        Optional<Plugin> fawe = Arrays.stream(Bukkit.getPluginManager().getPlugins())
+                .filter(pl -> pl.getName().contains("FastAsyncWorldEdit"))
+                .findFirst();
+        if (fawe.isPresent()) {
+            return getLineFawe(data, line);
+        }
+        return getLineWe(data, line);
+    }
+
+    /**
+     * <p>Parses data from a sign's NBT and returns the specified line number.
+     * Designed for <b>WorldEdit</b> NBT format.</p>
+     * <p>Compatibility with version 1.20.4 has been added.</p>
+     */
+    private static String getLineWe(@NotNull CompoundTag data, @Positive int line) {
+        List<String> lines = data.toString().lines().toList();
+
+        for (String s : lines) {
+            s = s.trim().replace("{\"text\":", "").replace("}", ""); // support for versions below 1.20.4
+
+            if (s.startsWith("TAG_String(\"") && !s.equals("TAG_String(\"\")")) {
+                values.add(s.replace("TAG_String(\"", "").replace("\")", ""));
+            }
+        }
+        // lines in versions below 1.20.4 duplicated twice
+        if (data.toString().contains("{\"text\":")) {
+            for (int i = (values.size() / 2); i != values.size();) {
+                if (values.size() == 2) break;
+                values.remove(i);
+            }
+            Collections.reverse(values);
+        }
+
+        if (line <= values.size()) {
+            return values.get(line - 1);
+        }
+        return "";
+    }
+
+    /**
+     * <p>Parses data from a sign's NBT and returns the specified line number.
+     * Designed for <b>FastAsyncWorldEdit</b> NBT format.</p>
+     * <p>Compatibility with version 1.20.4 has been added.</p>
+     */
+    private static String getLineFawe(@NotNull CompoundTag data, @Positive int line) {
+        // 1.20.4 have a different format of NBT
+        String str = data.toString()
+                .replace("{\\\\\"text\\\\\":", "")
+                .replace("}", "");
+
+        Matcher matcher = Pattern.compile("value=\"\\\\\\\\\"(.*?)\\\\\\\\\"\"")
+                .matcher(str);
+
+        while (values.size() < 2 && matcher.find()) {
+            String match = matcher.group(1);
+            if (match.isEmpty()) continue;
+            values.add(match);
+        }
+        // versions below 1.20.4 have reversed order of the lines (from 4 to 1)
+        if (data.toString().contains("{\\\\\"text\\\\\":")) {
+            Collections.reverse(values);
+        }
+
+        if (line <= values.size()) {
+            return values.get(line - 1);
+        }
+        return "";
     }
 }


### PR DESCRIPTION
## Description
In version 1.20.4, the NBT tag format for signs was changed, which caused the method String getLine(BaseBlock baseBlock, int line) to not work for schematics created on 1.20.4.
Examples of the new and old formats are given below.

Tested the current code on WorldEdit and FastAsyncWorldEdit for schematics from 1.20.4, as well as on structures from the [free pack](https://magmaguy.itch.io/bs-default-builds). 

## Changes 

Moved the static methods for parsing lines from `com.magmaguy.betterstructures.schematics.SchematicContainer` to `com.magmaguy.betterstructures.util.WorldEditUtils`.

Also implemented separate methods for parsing for FAWE and WorldEdit. Added javadoc comments to all of this.

## FastAsyncWorldEdit
### Old format
```
BinaryTagType[CompoundBinaryTag 10]{tags={"Color"=BinaryTagType[StringBinaryTag 8]{value="black"}, "is_waxed"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "Text4"=BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, "Text3"=BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, "Text2"=BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"pillager\\"}"}, "Text1"=BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"[spawn]\\"}"}, "front_text"=BinaryTagType[CompoundBinaryTag 10]{tags={"messages"=BinaryTagType[ListBinaryTag 9]{tags=[BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"[spawn]\\"}"}, BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"pillager\\"", BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}], type=BinaryTagType[StringBinaryTag 8]}, "has_glowing_text"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "color"=BinaryTagType[StringBinaryTag 8]{value="black"}}}, "back_text"=BinaryTagType[CompoundBinaryTag 10]{tags={"messages"=BinaryTagType[ListBinaryTag 9]{tags=[BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}, BinaryTagType[StringBinaryTag 8]{value="{\\"text\\":\\"\\"}"}], type=BinaryTagType[StringBinaryTag 8]}, "has_glowing_text"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "color"=BinaryTagType[StringBinaryTag 8]{value="black"}}}, "GlowingText"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "x"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=9}, "y"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=5}, "z"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=9}, "id"=BinaryTagType[StringBinaryTag 8]{value="minecraft:sign"}}}
```
### New format
```
{"back_text"=BinaryTagType[CompoundBinaryTag 10]{tags={"messages"=BinaryTagType[ListBinaryTag 9]{tags=[BinaryTagType[StringBinaryTag 8]{value="\\"\\""}, BinaryTagType[StringBinaryTag 8]{value="\\"\\""}, BinaryTagType[StringBinaryTag 8]{value="\\"\\""}, BinaryTagType[StringBinaryTag 8]{value="\\"\\""}], type=BinaryTagType[StringBinaryTag 8]}, "has_glowing_text"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "color"=BinaryTagType[StringBinaryTag 8]{value="black"}}}, "is_waxed"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "x"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=13}, "y"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=3}, "z"=BinaryTagType[IntBinaryTag 3 (numeric)]{value=16}, "id"=BinaryTagType[StringBinaryTag 8]{value="minecraft:sign"}, 
"front_text"=BinaryTagType[CompoundBinaryTag 10]{tags={"messages"=BinaryTagType[ListBinaryTag 9]{tags=[BinaryTagType[StringBinaryTag 8]{value="\\"[spawn]\\""}, BinaryTagType[StringBinaryTag 8]**{value="\\"EVOKER\\""}**, BinaryTagType[StringBinaryTag 8]{value="\\"\\""}, BinaryTagType[StringBinaryTag 8]{value="\\"\\""}], type=BinaryTagType[StringBinaryTag 8]}, "has_glowing_text"=BinaryTagType[ByteBinaryTag 1 (numeric)]{value=0}, "color"=BinaryTagType[StringBinaryTag 8]{value="black"}}}}}
```
> {\\"text\\":\\"[spawn]\\"}"}  to {value="\\"[spawn]\\""} and changed the order of lines

## WorldEdit
### Old format
``` 
TAG_Compound: 13 entries
{
   TAG_String(black)
   TAG_Byte(0)
   TAG_String({"text":""})
   TAG_String({"text":""})
   TAG_String({"text":"vindicator"})
   TAG_String({"text":"[spawn]"})
   TAG_Compound: 3 entries
   {
      TAG_Byte(0)
      TAG_String(black)
      TAG_List: 4 entries of type TAG_String
      {
         TAG_String({"text":"[spawn]"})
         TAG_String({"text":"vindicator"})
         TAG_String({"text":""})
         TAG_String({"text":""})
      }
   }
   TAG_Compound: 3 entries
   {
      TAG_Byte(0)
      TAG_String(black)
      TAG_List: 4 entries of type TAG_String
      {
         TAG_String({"text":""})
         TAG_String({"text":""})
         TAG_String({"text":""})
         TAG_String({"text":""})
      }
   }
   TAG_Byte(0)
   TAG_Int(8)
   TAG_Int(5)
   TAG_Int(8)
   TAG_String(minecraft:sign)
}
```

### New format
```
TAG_Compound: 7 entries
{
   TAG_Compound: 3 entries
   {
      TAG_Byte(0)
      TAG_String(black)
      TAG_List: 4 entries of type TAG_String
      {
         TAG_String("")
         TAG_String("")
         TAG_String("")
         TAG_String("")
      }
   }
   TAG_Byte(0)
   TAG_Int(3)
   TAG_Int(1)
   TAG_Int(19)
   TAG_String(minecraft:sign)
   TAG_Compound: 3 entries
   {
      TAG_Byte(0)
      TAG_String(black)
      TAG_List: 4 entries of type TAG_String
      {
         TAG_String("[spawn]")
         TAG_String("vindicator")
         TAG_String("")
         TAG_String("")
      }
   }
}
```